### PR TITLE
Add pop(idx) support to both single and double linked list implementations

### DIFF
--- a/src/dllist.c
+++ b/src/dllist.c
@@ -1018,7 +1018,7 @@ static PyObject* dllist_pop(DLListObject* self, PyObject *arg)
         return dllist_popright( self );
     }
 
-    if (self->first == Py_None)
+    if ( (PyObject*)self->first == Py_None)
     {
         PyErr_SetString(PyExc_ValueError, "List is empty");
         return NULL;
@@ -1047,33 +1047,33 @@ static PyObject* dllist_pop(DLListObject* self, PyObject *arg)
     }
 
     /* Start at first node, and walk to the one we will pop */
-    prev_node = (DLListObject*)Py_None;
+    prev_node = (DLListNodeObject*)Py_None;
     del_node = (DLListNodeObject*)self->first;
     for(i=0; i < index; i++) {
         prev_node = del_node;
-        del_node = del_node->next;
+        del_node = (DLListNodeObject*)del_node->next;
     }
 
-    if ( prev_node == Py_None )
+    if ( (PyObject*)prev_node == Py_None )
     {
         /* First node */
-        self->first = del_node->next;
+        self->first = (PyObject*)del_node->next;
     }
     else
     {
         /* Any other node */
         prev_node->next = del_node->next;
     }
-    if(del_node->next != Py_None)
+    if ( (PyObject*)del_node->next != Py_None )
     {
-        ((DLListNodeObject*)del_node->next)->prev = prev_node;
+        ((DLListNodeObject*)del_node->next)->prev = (PyObject*)prev_node;
     }
 
     --self->size;
     if ( index == self->size )
     {
         /* removeing last node, move last pointer */
-        self->last = prev_node;
+        self->last = (PyObject*)prev_node;
     }
 
 

--- a/src/dllist.c
+++ b/src/dllist.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2011-2013 Adam Jakubek, Rafał Gałczyński
+ * Copyright (c) 2017 Timothy Savannah
  * Released under the MIT license (see attached LICENSE file).
  */
 

--- a/src/dllist.c
+++ b/src/dllist.c
@@ -1077,12 +1077,18 @@ static PyObject* dllist_pop(DLListObject* self, PyObject *arg)
         self->last = (PyObject*)prev_node;
     }
 
+    if (self->last_accessed_node == (PyObject*)del_node)
+    {
+        /* invalidate last accessed item */
+        self->last_accessed_node = Py_None;
+        self->last_accessed_idx = -1;
+    }
+
 
     Py_INCREF(del_node->value);
     value = del_node->value;
 
-    del_node->next = Py_None;
-    Py_DECREF((PyObject*)del_node);
+    dllistnode_delete(del_node);
 
     return value;
 }

--- a/src/sllist.c
+++ b/src/sllist.c
@@ -1409,7 +1409,7 @@ static PyMethodDef SLListMethods[] =
       "Return node at index" },
 
     { "pop", (PyCFunction)sllist_pop, METH_VARARGS,
-      "Remove a given element from the list and return it. Defaults to last" },
+      "Remove an element by index from the list and return it, or last item if no index provided" },
 
     { "popleft", (PyCFunction)sllist_popleft, METH_NOARGS,
       "Remove first element from the list and return it" },

--- a/src/sllist.c
+++ b/src/sllist.c
@@ -1214,14 +1214,14 @@ static PyObject* sllist_pop(SLListObject* self, PyObject *arg)
     }
 
     /* Start at first node, and walk to the one we will pop */
-    prev_node = Py_None;
+    prev_node = (SLListNodeObject*)Py_None;
     del_node = (SLListNodeObject*)self->first;
     for(i=0; i < index; i++) {
         prev_node = del_node;
-        del_node = del_node->next;
+        del_node = (SLListNodeObject*)del_node->next;
     }
 
-    if ( prev_node == Py_None )
+    if ( (PyObject*)prev_node == Py_None )
     {
         /* First node */
         self->first = del_node->next;
@@ -1236,7 +1236,7 @@ static PyObject* sllist_pop(SLListObject* self, PyObject *arg)
     if ( index == self->size )
     {
         /* removeing last node, move last pointer */
-        self->last = prev_node;
+        self->last = (PyObject*)prev_node;
     }
 
 

--- a/tests/llist_test.py
+++ b/tests/llist_test.py
@@ -553,6 +553,28 @@ class testsllist(unittest.TestCase):
         self.assertEqual(list(ll), ref[:-1])
         self.assertEqual(del_node.next, None)
 
+        ref = py23_range(0, 1024, 4)
+        ll = sllist(ref)
+        
+        result = ll.pop(1)
+        self.assertEqual(result, ref[1])
+        result = ll.pop(1)
+        self.assertEqual(result, ref[2])
+        self.assertEqual(ll.size, len(ref)-2)
+
+        ref = py23_range(0, 1024, 4)
+        ll = sllist(ref)
+        result = ll.pop(0)
+        self.assertEqual(result, ref[0])
+        
+        self.assertEqual(ll.first.value, ref[1])
+        for i in range(len(ll)):
+            ll.pop(0)
+        self.assertEqual(ll.first, None)
+        self.assertEqual(ll.last, None)
+
+        
+
     def test_popleft(self):
         ref = py23_range(0, 1024, 4)
         ll = sllist(ref)

--- a/tests/llist_test.py
+++ b/tests/llist_test.py
@@ -1294,6 +1294,33 @@ class testdllist(unittest.TestCase):
         self.assertEqual(del_node.prev, None)
         self.assertEqual(del_node.next, None)
 
+        ref = py23_range(0, 1024, 4)
+        ll = dllist(ref)
+        
+        result = ll.pop(1)
+        self.assertEqual(result, ref[1])
+        result = ll.pop(1)
+        self.assertEqual(result, ref[2])
+        self.assertEqual(ll.size, len(ref)-2)
+
+        secondNode = ll.nodeat(1)
+
+        self.assertEquals(secondNode.prev, ll.first)
+        self.assertEquals(ll.first.prev, None)
+
+        ref = py23_range(0, 1024, 4)
+        ll = dllist(ref)
+        result = ll.pop(0)
+        self.assertEqual(result, ref[0])
+        
+        self.assertEqual(ll.first.value, ref[1])
+        for i in range(len(ll)):
+            ll.pop(0)
+        self.assertEqual(ll.first, None)
+        self.assertEqual(ll.last, None)
+
+        
+
     def test_popleft(self):
         ref = py23_range(0, 1024, 4)
         ll = dllist(ref)


### PR DESCRIPTION
Hey bud,

This patch adds .pop(idx) to both linked and double-linked list implementation.

This follows the same pattern as  the standard python list, where an index can be provided (positive or negative) to the pop function to pop a specific element.

The index is optional, and if not provided defaults to popright (so backwards-compatible, and compatible with base list).

Please consider merging and re-releasing with the addition of this patch.

The primary advantage of a linked-list or double-linked-list versus an array is the ability to pop items from the middle without rebuilding the entire list. This adds that benefit to these implementations, and thus allows them to out-perform the base python list for various scenarios.

Thanks,
Tim