### PR TITLE
Fix sllist append tests

### DIFF
--- a/tests/llist_test.py
+++ b/tests/llist_test.py
@@ -278,12 +278,12 @@ class testsllist(unittest.TestCase):
     def test_append_left(self):
         ll = sllist([1, 2, 3, 4])
         ll.appendleft(5)
-        self.assertTrue([5, 1, 2, 3, 4], list(ll))
+        self.assertEqual([5, 1, 2, 3, 4], list(ll))
 
     def test_append_right(self):
         ll = sllist([1, 2, 3, 4])
         ll.appendleft(5)
-        self.assertTrue([1, 2, 3, 4, 5], list(ll))
+        self.assertEqual([1, 2, 3, 4, 5], list(ll))
 
     def test_pop_left_from_one_elem(self):
         ll = sllist(py23_xrange(0, 100))

--- a/tests/llist_test.py
+++ b/tests/llist_test.py
@@ -282,7 +282,7 @@ class testsllist(unittest.TestCase):
 
     def test_append_right(self):
         ll = sllist([1, 2, 3, 4])
-        ll.appendleft(5)
+        ll.appendright(5)
         self.assertEqual([1, 2, 3, 4, 5], list(ll))
 
     def test_pop_left_from_one_elem(self):


### PR DESCRIPTION
The tests for `sllist`'s `appendleft` and `appendright` incorrectly use `assertTrue` but should use `assertEqual` instead. 

Additionally, `test_append_right` was calling `ll.appendleft` not `ll.appendright`