### PR TITLE
Fixes for python built in debug-mode

### DIFF
--- a/src/dllist.c
+++ b/src/dllist.c
@@ -203,6 +203,7 @@ static int dllistnode_clear_refs(DLListNodeObject* self)
 
 static void dllistnode_dealloc(DLListNodeObject* self)
 {
+    PyObject_GC_UnTrack(self);
     PyObject* obj_self = (PyObject*)self;
 
     dllistnode_clear_refs(self);
@@ -606,6 +607,7 @@ static int dllist_clear_refs(DLListObject* self)
 
 static void dllist_dealloc(DLListObject* self)
 {
+    PyObject_GC_UnTrack(self);
     PyObject* obj_self = (PyObject*)self;
 
     dllist_clear_refs(self);
@@ -1758,6 +1760,7 @@ static int dllistiterator_clear_refs(DLListIteratorObject* self)
 
 static void dllistiterator_dealloc(DLListIteratorObject* self)
 {
+    PyObject_GC_UnTrack(self);
     PyObject* obj_self = (PyObject*)self;
 
     dllistiterator_clear_refs(self);

--- a/src/sllist.c
+++ b/src/sllist.c
@@ -131,6 +131,7 @@ static int sllistnode_clear_refs(SLListNodeObject* self)
 
 static void sllistnode_dealloc(SLListNodeObject* self)
 {
+    PyObject_GC_UnTrack(self);
     PyObject* obj_self = (PyObject*)self;
 
     sllistnode_clear_refs(self);
@@ -373,6 +374,7 @@ static int sllist_clear_refs(SLListObject* self)
 
 static void sllist_dealloc(SLListObject* self)
 {
+    PyObject_GC_UnTrack(self);
     PyObject* obj_self = (PyObject*)self;
 
     sllist_clear_refs(self);
@@ -1722,6 +1724,7 @@ static int sllistiterator_clear_refs(SLListIteratorObject* self)
 
 static void sllistiterator_dealloc(SLListIteratorObject* self)
 {
+    PyObject_GC_UnTrack(self);
     PyObject* obj_self = (PyObject*)self;
 
     sllistiterator_clear_refs(self);


### PR DESCRIPTION
For reproduce
* Download Python 3.11
* ./configure --with-pydebug
* make
* run example or run tests with this python
```(python)
from llist import dllist, dllistnode
import sys
original_ref_count = sys.getrefcount(None)
for _ in range(original_ref_count * 10):
    ll = dllist()
    ll.append(dllistnode(ll))
    del ll
```
* Crash with log
```
gc:0: ResourceWarning: Object of type llist.dllistnode is not untracked before destruction
<dllistnode(dllist([dllist(<...>)]))>
Modules/gcmodule.c:442: update_refs: Assertion "gc_get_refs(gc) != 0" failed
Enable tracemalloc to get the memory block allocation traceback

object address  : 0x7efdb6c7fe30
object refcount : 0
object type     : 0x7efdb6e905c0
object type name: llist.dllistnode
object repr     : <refcnt 0 at 0x7efdb6c7fe30>

Fatal Python error: _PyObject_AssertFailed: _PyObject_AssertFailed
Python runtime state: initialized

Current thread 0x00007efdb7741280 (most recent call first):
  Garbage-collecting
  File "/home/shadchin/t/3/Python-3.11.2/Lib/posixpath.py", line 82 in join
  File "/home/shadchin/t/3/Python-3.11.2/Lib/linecache.py", line 124 in updatecache
  File "/home/shadchin/t/3/Python-3.11.2/Lib/linecache.py", line 46 in getlines
  File "/home/shadchin/t/3/Python-3.11.2/Lib/linecache.py", line 30 in getline
  File "/home/shadchin/t/3/Python-3.11.2/Lib/warnings.py", line 42 in _formatwarnmsg_impl
  File "/home/shadchin/t/3/Python-3.11.2/Lib/warnings.py", line 128 in _formatwarnmsg
  File "/home/shadchin/t/3/Python-3.11.2/Lib/warnings.py", line 28 in _showwarnmsg_impl
  File "/home/shadchin/t/3/Python-3.11.2/Lib/warnings.py", line 112 in _showwarnmsg
  File "<stdin>", line 3 in <module>

Extension modules: llist (total: 1)
Aborted
```

About debug mode - https://docs.python.org/3/using/configure.html#debug-build